### PR TITLE
PageSize parameter with optional size and parameter name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,8 @@ jobs:
     docker:
       - image: ${ACR_HOSTNAME_COMMON}/alpine-php82-build:2.2.1
         auth:
-          username: ${ACR_LOGIN_PD}
-          password: ${ACR_PASSWORD_PD}
+          username: ${ACR_LOGIN_COMMON}
+          password: ${ACR_PASSWORD_COMMON}
     resource_class: large
     working_directory: /var/www/html
     steps:
@@ -27,10 +27,10 @@ jobs:
 
   static:
     docker:
-      - image: ${ACR_HOSTNAME_PD}/alpine-php81-apache-build:latest
+      - image: ${ACR_HOSTNAME_COMMON}/alpine-php82-build:2.2.1
         auth:
-          username: ${ACR_LOGIN_PD}
-          password: ${ACR_PASSWORD_PD}
+          username: ${ACR_LOGIN_COMMON}
+          password: ${ACR_PASSWORD_COMMON}
     working_directory: /var/www/html
     resource_class: large
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ composer_install: &composer_install
 jobs:
   build:
     docker:
-      - image: ${ACR_HOSTNAME_PD}/alpine-php82-build:2.1.0
+      - image: ${ACR_HOSTNAME_COMMON}/alpine-php82-build:2.2.1
         auth:
           username: ${ACR_LOGIN_PD}
           password: ${ACR_PASSWORD_PD}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ composer_install: &composer_install
 jobs:
   build:
     docker:
-      - image: ${ACR_HOSTNAME_PD}/alpine-php81-apache-build:1.13.0
+      - image: ${ACR_HOSTNAME_PD}/alpine-php82-build:2.1.0
         auth:
           username: ${ACR_LOGIN_PD}
           password: ${ACR_PASSWORD_PD}

--- a/src/OpenApiDocumentation/OAPageSizeParameter.php
+++ b/src/OpenApiDocumentation/OAPageSizeParameter.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace BaywaReLusy\OpenApiDocumentation;
+
+use OpenApi\Attributes\Attachable;
+use OpenApi\Attributes\JsonContent;
+use OpenApi\Attributes\Parameter;
+use OpenApi\Attributes\Schema;
+use OpenApi\Attributes\XmlContent;
+use OpenApi\Generator;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
+class OAPageSizeParameter extends Parameter
+{
+    public function __construct(
+        ?int $size = null,
+        ?string $parameter = null
+    ) {
+        if (is_null($parameter)) {
+            $parameter = 'page_size';
+        }
+        if (is_null($size)) {
+            $size = 25;
+        }
+
+        parent::__construct(
+            $parameter,
+            $parameter,
+            'Number of elements returned per page',
+            'query',
+            false,
+            null,
+            null,
+            null,
+            new Schema(type: "integer"),
+            $size
+        );
+    }
+}


### PR DESCRIPTION
Shortcut for the "default" Laminas pagination size parameter:

`parameters: [
     new OAPageSizeParameter()
 ],`

Will result in:

![image](https://github.com/user-attachments/assets/d32b440a-aab7-4123-b0b2-edfdccaf499b)

Optional size and name can be overriden:

`new OAPageSizeParameter(100, 'custom_page_size')`